### PR TITLE
Adding the HTTP request to the weatherstack API

### DIFF
--- a/app.js
+++ b/app.js
@@ -1,9 +1,18 @@
 const request = require('request')
 
-//const url = 'http://api.weatherstack.com/current?access_key=83feab2a74815c77e3bc05ec4ddb999d&query=6.1375,1.2123&units=f'
+const weatherStackUrl = `http://api.weatherstack.com/current?access_key=83feab2a74815c77e3bc05ec4ddb999d&query=6.1375,1.2123&units=f`
 
-const url = 'https://api.mapbox.com/geocoding/v5/mapbox.places/Los%20Angeles.json?access_token=pk.eyJ1Ijoib3BlbnRlY2hjb25zdWx0IiwiYSI6ImNrdGozamRncTE3eHEyb2pvdTcyMTB3YTAifQ._G-Ff_bRHIW5AuuS1Miipg'
-
-request({url: url, json: true}, (err, response) => {
-    console.log(`${response.body.query[0]} ${response.body.query[1]} is at longitude ${response.body.features[0].center[0]} and latitude ${response.body.features[0].center[1]}`)
+request({ url: weatherStackUrl, json: true}, (err, response) => {
+    const temperature = response.body.current.temperature
+    const feelsLike = response.body.current.feelslike
+    console.log(`It is ${temperature}° but it feels like ${feelsLike}°`)
 })
+
+const geocodeUrl = `https://api.mapbox.com/geocoding/v5/mapbox.places/Los%20Angeles.json?access_token=pk.eyJ1Ijoib3BlbnRlY2hjb25zdWx0IiwiYSI6ImNrdGozamRncTE3eHEyb2pvdTcyMTB3YTAifQ._G-Ff_bRHIW5AuuS1Miipg`
+
+request({url: geocodeUrl, json: true}, (err, response) => {
+    const place_name = response.body.features[0].place_name
+    const [longitude, latitude] = response.body.features[0].center
+    console.log(`${place_name} is at longitude ${longitude} and latitude ${latitude}`)
+})
+

--- a/app.js
+++ b/app.js
@@ -15,4 +15,3 @@ request({url: geocodeUrl, json: true}, (err, response) => {
     const [longitude, latitude] = response.body.features[0].center
     console.log(`${place_name} is at longitude ${longitude} and latitude ${latitude}`)
 })
-


### PR DESCRIPTION
In the previous commit we deleted the call to the weather stack API and we made a call to mapbox API instead.
In this issue we are puting back the call to the weather stack API. The project now has two call to external APIs

make a call to weather stack API and console log the temperature data

Resolve #5